### PR TITLE
Using Rs CFLAGS and LDFLAGS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ShortRead
 Type: Package
 Title: FASTQ input and manipulation
-Version: 1.43.1
+Version: 1.43.2
 Author: Martin Morgan, Michael Lawrence, Simon Anders
 Maintainer: Bioconductor Package Maintainer
         <maintainer@bioconductor.org>

--- a/configure
+++ b/configure
@@ -2104,6 +2104,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+# Check the compiler configured with R
+: ${R_HOME=`R RHOME`}
+if test -z "${R_HOME}"; then
+  echo "could not determine R_HOME"
+  exit 1
+fi
+
+CC=`"${R_HOME}/bin/R" CMD config CC`
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
+LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,16 @@
 AC_INIT("DESCRIPTION")
 
+# Check the compiler configured with R
+: ${R_HOME=`R RHOME`}
+if test -z "${R_HOME}"; then
+  echo "could not determine R_HOME"
+  exit 1
+fi
+
+CC=`"${R_HOME}/bin/R" CMD config CC`
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
+LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+
 AC_CHECK_LIB([z], [gzeof], , AC_ERROR([zlib not found]))
 AC_CHECK_SIZEOF([unsigned long])
 


### PR DESCRIPTION
This PR forces ShortRead to use the CFLAGS and LDFLAGS from R. Without this PR, zlib appears to  not be working, in case it requires specific flags such as `-I` and/or `-L`.

`configure` was regenerated using autoconf 2.69.

This is a critical bug fix since it prevents ShortRead from being installed. It should be back ported to release.