### PR TITLE
Correct heuristic for qualityType="Auto"

### DIFF
--- a/R/methods-ShortReadQ.R
+++ b/R/methods-ShortReadQ.R
@@ -47,7 +47,7 @@ setMethod(ShortReadQ, c("DNAStringSet", "BStringSet", "BStringSet"),
                 alf <- alphabetFrequency(head(quality, 10000),
                                          collapse=TRUE)
                 wch <- which(alf != 0)
-                if (any(alf) && (min(wch) >= 58) && (max(wch) > 74)) {
+                if (any(alf) && (min(wch) > 59) && (max(wch) > 75)) {
                     SFastqQuality
                 } else FastqQuality
             }, SFastqQuality=SFastqQuality, FastqQuality=FastqQuality)


### PR DESCRIPTION
The manual says:
qualityType:Representation to be used for quality scores, must be one of Auto(choose  Illumina  base  64  encodingSFastqQuality if  all  characters  are ASCII-encoded as greater than 58: and some characters are greater than74J),FastqQuality(Phred-like base 33 encoding),SFastqQuality(Il-lumina base 64 encoding).

Unfortunately the current decision boundaries are between 8 and 9, and I and J :#
This is what my R says:
```
> library("Biostrings")
> which(alphabetFrequency(BStringSet("89:;IJK")) != 0)
[1] 57 58 59 60 74 75 76
```

As a result, this "obviously Illumina 1.8+ "(*) read is incorrectly interpreted as a Solexa read:
```
> library("ShortRead")
> quality(ShortReadQ(DNAStringSet("AA"), BStringSet("9J")))
class: SFastqQuality
quality:
  A BStringSet instance of length 1
    width seq
[1]     2 9J
```

I think the source of the mistake is that ASCII codes are not the same as indexes in alphabetFrequency, because in R indexes are 1-based. As to why I think how the error survived for so long - it is not off by much at all, and I only encountered it because of an automated check in a package `dada2`, failing on a file from 2012 with five PCR reads. Those reads are definitely scored as "Phred+33" because they had the character `#` which was then trimmed off. The untrimmed reads had the character `:` in a few places, as well as a few `J`s (but no `K`s or higher), which made `ShortRead` interpret them as Solexa reads. That was bad, because the character `:` was interpreted as an impossible "-7".


(*) I'm using the diagram on https://en.wikipedia.org/wiki/FASTQ_format to inspire these examples. The diagram also convinces me that what the manual says the heuristic is is correct, as opposed to what the heuristic actually is.