### PR TITLE
Fix Wformat-security warning

### DIFF
--- a/src/readBfaToc.cc
+++ b/src/readBfaToc.cc
@@ -27,7 +27,7 @@ extern "C" SEXP readBfaToc( SEXP bfa_filename )
       char buf[300];
       snprintf( buf, 300, "Failed to open file '%s': %s (errno=%d)",
          CHAR(STRING_ELT(bfa_filename,0)), strerror(errno), errno );
-      error( buf );
+      error( "%s", buf );
    }
    while( fread( &name_len, sizeof(int), 1, fp) ) {
       if( name_len > 200 )


### PR DESCRIPTION
If I add `"%s",` to `error`, I no longer see the error. In the previous examples, I saw the fix for `Rf_error()`. Could I just ask you to verify if this is correct?

```
 ~/R/bin/R CMD INSTALL --configure-args="CFLAGS=-Werror=format-security CXXFLAGS=-Werror=format-security" .
* installing to library ‘/home/meatbag/R/library’
* installing *source* package ‘ShortRead’ ...
** using staged installation
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for gzeof in -lz... yes
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking size of unsigned long... 8
configure: creating ./config.status
config.status: creating src/Makevars
** libs
using C compiler: ‘gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0’
using C++ compiler: ‘g++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0’
g++ -std=gnu++17 -I"/home/meatbag/R/include" -DNDEBUG  -I'/home/meatbag/R/library/S4Vectors/include' -I'/home/meatbag/R/library/IRanges/include' -I'/home/meatbag/R/library/XVector/include' -I'/home/meatbag/R/library/Biostrings/include' -I'/home/meatbag/R/library/Rhtslib/include' -I'/home/meatbag/R/library/zlibbioc/include' -I/usr/local/include   -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DHAVE_LIBZ=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DSIZEOF_UNSIGNED_LONG=8 -fpic  -g -O2  -Wall -c readBfaToc.cc -o readBfaToc.o
readBfaToc.cc: In function ‘SEXPREC* readBfaToc(SEXP)’:
readBfaToc.cc:35:19: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   35 |       (void) fread( seq_name, sizeof(char), name_len, fp );
      |              ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
readBfaToc.cc:36:19: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   36 |       (void) fread( &seq_ori_len, sizeof(int), 1, fp );
      |              ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
readBfaToc.cc:37:19: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   37 |       (void) fread( &seq_len, sizeof(int), 1, fp );
      |              ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
g++ -std=gnu++17 -shared -L/home/meatbag/R/lib -L/usr/local/lib -o ShortRead.so Biostrings_stubs.o IRanges_stubs.o R_init_ShortRead.o S4Vectors_stubs.o XVector_stubs.o alphabet.o count.o io.o io_bowtie.o io_soap.o readBfaToc.o read_maq_map.o sampler.o trim.o util.o xsnap.o -lz -fopenmp -L/home/meatbag/R/lib -lR
installing to /home/meatbag/R/library/00LOCK-ShortRead/00new/ShortRead/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (ShortRead)
```